### PR TITLE
[ci skip] Fix spelling errors

### DIFF
--- a/src/MDCProblem.jl
+++ b/src/MDCProblem.jl
@@ -51,7 +51,7 @@ specify_curve(;cost=nothing, p0=nothing, dp0=nothing,momentum=nothing,tspan=noth
 
 """
     (c::MDCProblem)()
-returns a tuple of ODEProblems specificed by the MDCProblem. Usually a single ODEProblem. Two are provided if the curve crosses zero, so that one can run two curves in parallel going backwards/forwards from zero
+returns a tuple of ODEProblems specified by the MDCProblem. Usually a single ODEProblem. Two are provided if the curve crosses zero, so that one can run two curves in parallel going backwards/forwards from zero
 """
 function (c::MDCProblem)()
     spans = make_spans(c, c.tspan)


### PR DESCRIPTION
## Summary

This PR fixes spelling errors identified by automated spell checking.

## Changes Made

- specificed -> specified

## Notes

-  included to avoid unnecessary CI runs for spelling fixes
- Only fixed clear, obvious spelling errors
- Changes are typically in comments, documentation, or string literals
- Does not affect functionality