### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MinimallyDisruptiveCurves"
 uuid = "c6328df5-4af8-4637-a9e9-78ed74a2ae2b"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Dhruva Venkita Raman"]
 
 [deps]
@@ -24,7 +24,7 @@ ModelingToolkit = "8, 9"
 OrdinaryDiffEq = "6, 7"
 PrecompileTools = "1"
 RecipesBase = "1"
-SciMLBase = "2"
+SciMLBase = "2, 3.1"
 SteadyStateDiffEq = "2"
 ThreadsX = "0.1.8"
 julia = "1.10"


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

Extend `SciMLBase` compat to include v3.1 (keep the existing lower bound and v2 support). No code changes required — a grep of `src/` and `test/` found no references to the SciMLBase v3 breaking surface (`u_modified!`, removed `DEProblem` type alias, 3-arg ensemble `prob_func`, single-int non-scalar timeseries `sol[i]` indexing, or removed getproperty aliases like `.destats` / `.minimizer`).

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54` while SciMLBase 3.1 requires RAT v4. Expect CI on this PR to fail at the `Pkg.add` step with an unsatisfiable resolution error until upstream OrdinaryDiffEq releases a RAT-v4-compatible version; re-running afterward should go green without further edits.

## Context

Part of the SciMLBase v3 ecosystem sweep — see SciML/DiffEqCallbacks.jl#300 and SciML/DiffEqParamEstim.jl#290 for the reference patterns for code-side changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)