### PR TITLE
Bump compat for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
       - uses: fredrikekre/runic-action@v1
         with:
           version: '1'

--- a/src/MinimallyDisruptiveCurves.jl
+++ b/src/MinimallyDisruptiveCurves.jl
@@ -4,7 +4,7 @@ using DiffEqCallbacks: DiffEqCallbacks, FunctionCallingCallback, PresetTimeCallb
     SavedValues, SavingCallback
 using FiniteDiff: FiniteDiff
 using ForwardDiff: ForwardDiff
-using LinearAlgebra: LinearAlgebra, I, diagm, dot, norm, svd
+using LinearAlgebra: LinearAlgebra, diagm, dot, norm, svd
 using ModelingToolkit: ModelingToolkit, Num, ODEFunction, ODEProblem, ODESystem,
     Variable, equations, independent_variable, modelingtoolkitize,
     parameters, structural_simplify, substitute, unknowns

--- a/src/evolve.jl
+++ b/src/evolve.jl
@@ -12,11 +12,11 @@ function evolve(
         (mdc_callback = convert(Vector{CallbackCallable}, mdc_callback))
 
     function merge_sols(ens, p)
-        if length(ens) == 1
-            return ens[1]
-        elseif length(ens) == 2
-            t = cat(-ens[1].t[end:-1:1], ens[2].t, dims = 1)
-            u = cat(ens[1].u[end:-1:1], ens[2].u, dims = 1)
+        if length(ens.u) == 1
+            return ens.u[1]
+        elseif length(ens.u) == 2
+            t = cat(-ens.u[1].t[end:-1:1], ens.u[2].t, dims = 1)
+            u = cat(ens.u[1].u[end:-1:1], ens.u[2].u, dims = 1)
             return SciMLBase.build_solution(p, Tsit5(), t, u)
         end
     end

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -64,7 +64,7 @@ using PrecompileTools: @setup_workload, @compile_workload
 
         # evolve - the main entry point
         # Use a very short span to minimize precompilation time
-        mdc = evolve(eprob, Tsit5; mdc_callback = cb, verbose = false)
+        mdc = evolve(eprob, Tsit5; mdc_callback = cb)
 
         # MDCSolution methods
         _ = trajectory(mdc)


### PR DESCRIPTION
## Summary

This PR updates MinimallyDisruptiveCurves.jl for the OrdinaryDiffEq v7 / SciMLBase v3 ecosystem (refs SciML/OrdinaryDiffEq.jl#3562, SciML/OrdinaryDiffEq.jl#3565; see [NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)).

The compat bounds (`OrdinaryDiffEq = "6, 7"` and `SciMLBase = "2, 3.1"`) were already set in PR #49. This PR adds the required source-level migrations:

### Changes

**`src/evolve.jl` — RecursiveArrayTools v4 `EnsembleSolution` indexing (breaking)**

RecursiveArrayTools v4 makes `AbstractVectorOfArray <: AbstractArray`, which changes the semantics of integer indexing: `ens[j]` now returns the j-th *scalar element* (column-major) rather than the j-th *trajectory*. Similarly, `length(ens)` returns total element count rather than trajectory count.

Migration: `ens[j]` → `ens.u[j]`, `length(ens)` → `length(ens.u)`.
This form works on both RAT v3 and v4 since `EnsembleSolution.u` has always been the vector of trajectories.

**`src/precompilation.jl` — `verbose::Bool` removed in OrdinaryDiffEq v7**

OrdinaryDiffEq v7 removes `verbose::Bool` support in `solve` (must use `ODEVerbosity(...)`). The precompilation workload was forwarding `verbose=false` through `kwargs...` to `solve`, which breaks on v7. Removing the kwarg is safe since verbosity is purely diagnostic.

**`src/MinimallyDisruptiveCurves.jl` — remove stale `I` import**

`I` (identity matrix) was in the `LinearAlgebra` import list but never used in source code, causing `check_no_stale_explicit_imports` to error in CI.

### Testing

All 20 tests pass locally against the currently-resolved environment (OrdinaryDiffEq v6.107 + SciMLBase v2.153). The `EnsembleSolution.u` indexing is backward-compatible with RAT v3.