### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ RecipesBase = "1.3"
 SafeTestsets = "0.1"
 SciMLBase = "3.17"
 SciMLStructures = "1.10"
+SciMLTesting = "1"
 Symbolics = "6, 7"
 Test = "1"
 julia = "1.10"
@@ -55,10 +56,10 @@ ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "BenchmarkTools", "DiffEqCallbacks", "ExplicitImports", "LinearAlgebra", "Test", "ForwardDiff", "OrdinaryDiffEq", "SafeTestsets", "Symbolics", "Pkg"]
+test = ["AllocCheck", "BenchmarkTools", "DiffEqCallbacks", "ExplicitImports", "LinearAlgebra", "Test", "ForwardDiff", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "Symbolics"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MinimallyDisruptiveCurves = "c6328df5-4af8-4637-a9e9-78ed74a2ae2b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -8,5 +10,7 @@ MinimallyDisruptiveCurves = {path = "../.."}
 
 [compat]
 JET = "0.9, 0.10, 0.11"
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,49 +1,31 @@
-using Test
 using SafeTestsets
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "QA"
-    using Pkg
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    Pkg.develop(path = joinpath(@__DIR__, ".."))
-    Pkg.instantiate()
-    include(joinpath(@__DIR__, "qa", "qa.jl"))
-else
-    @testset "MinimallyDisruptiveCurves.jl Suite" begin
-
-        # --- 1. CORE FUNCTIONAL TESTS ---
-        if GROUP == "All" || GROUP == "Core"
-            @safetestset "Transforms & Pullback Analytics" begin
-                include("test_transforms.jl")
-            end
-
-            @safetestset "Cost Wrapper Mechanics" begin
-                include("test_costs.jl")
-            end
-
-            @safetestset "Solver Pipelines & Integration" begin
-                include("test_solvers.jl")
-            end
-
-            @safetestset "Safety Controls & System Guards" begin
-                include("test_callbacks.jl")
-            end
+run_tests(;
+    core = function ()
+        @safetestset "Transforms & Pullback Analytics" begin
+            include(joinpath(@__DIR__, "test_transforms.jl"))
         end
-
-        # --- 2. PERFORMANCE ALLOCATION CHECKING ---
-        if GROUP == "All" || GROUP == "Core" || GROUP == "Alloc"
-            @safetestset "Allocation Checks" begin
-                include("alloc_tests.jl") # Keeps your allocation tests isolated
-            end
+        @safetestset "Cost Wrapper Mechanics" begin
+            include(joinpath(@__DIR__, "test_costs.jl"))
         end
-
-        # --- 3. LINTING AND IMPORT CLEANLINESS ---
-        if GROUP == "All" || GROUP == "Core" || GROUP == "ExplicitImports"
-            @safetestset "Explicit Imports Compliance" begin
-                include("explicit_imports.jl") # Verifies scoping rules
-            end
+        @safetestset "Solver Pipelines & Integration" begin
+            include(joinpath(@__DIR__, "test_solvers.jl"))
         end
-
-    end
-end
+        @safetestset "Safety Controls & System Guards" begin
+            include(joinpath(@__DIR__, "test_callbacks.jl"))
+        end
+        @safetestset "Allocation Checks" begin
+            include(joinpath(@__DIR__, "alloc_tests.jl"))
+        end
+        return @safetestset "Explicit Imports Compliance" begin
+            include(joinpath(@__DIR__, "explicit_imports.jl"))
+        end
+    end,
+    groups = Dict(
+        "Alloc" => joinpath(@__DIR__, "alloc_tests.jl"),
+        "ExplicitImports" => joinpath(@__DIR__, "explicit_imports.jl"),
+    ),
+    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
+    all = ["Core"],
+)


### PR DESCRIPTION
Converts `test/runtests.jl` to the SciMLTesting v1.2 declarative `run_tests` dispatcher.

This repo's group layout does not fit bare folder-discovery: `Alloc` and `ExplicitImports` are manual-only GROUP values (each a single-file sub-slice of `Core`, not declared in `test_groups.toml`), which folder-discovery would reject as unknown groups. The conversion therefore uses the v1.2 explicit-args form (still SciMLTesting v1.2) over the existing top-level file layout, preserving every GROUP value exactly:

- `Core` / `All` -> the six top-level test files (transforms, costs, solvers, callbacks, alloc, explicit_imports), each in its own `@safetestset`.
- `Alloc` -> `alloc_tests.jl` only.
- `ExplicitImports` -> `explicit_imports.jl` only.
- `QA` -> activates `test/qa` and runs `qa.jl`.
- `all = ["Core"]` curates `All` to exactly `Core`'s file set (matching master's `All`, which runs the same six files with no QA and no duplicates).

Dependency edits: add `SciMLTesting` (compat `1`) to the root test deps and to `test/qa/Project.toml` (plus `SafeTestsets` there); drop `Pkg` from the root test deps (no `test/*.jl` uses `Pkg`; the v1.2 harness owns all `Pkg` operations). `test/test_groups.toml` is unchanged.

Verified statically (TOML parse of all Project.toml + test_groups.toml; parse of runtests.jl + every test file) and by driving the real SciMLTesting v1.2.0 `run_tests` dispatch with marker files for `GROUP` in {All, Core, Alloc, ExplicitImports}: the fired-body set matches the previous dispatcher exactly.

Ignore until reviewed by @ChrisRackauckas.
