### PR TITLE
Drop redundant QA self source

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-MinimallyDisruptiveCurves = {path = "/home/crackauc/sandbox/tmp_20260708_051717_3275/repos/MinimallyDisruptiveCurves.jl"}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- remove the redundant self `[sources]` path from the QA project
- rely on SciMLTesting to develop the package under test for the QA group

## Verification
- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`\n- `git diff --check`\n\nThe fresh branch tree matches the locally tested tree from `agent/scimltesting-2-1-api-docs` after the same cleanup.