### PR TITLE
Release prep: bump MinimallyDisruptiveCurves to 0.4.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MinimallyDisruptiveCurves"
 uuid = "c6328df5-4af8-4637-a9e9-78ed74a2ae2b"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Dhruva Venkita Raman"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes since v0.4.1.