### PR TITLE
Make the strict-QA release non-breaking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MinimallyDisruptiveCurves"
 uuid = "c6328df5-4af8-4637-a9e9-78ed74a2ae2b"
-version = "0.5.0"
+version = "0.4.3"
 authors = ["Dhruva Venkita Raman"]
 
 [deps]


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `MinimallyDisruptiveCurves` | 0.5.0 | 0.4.3 | QA reexport removal is not a public API break |


## Why

The version was bumped to a breaking release because the strict SciMLTesting 2.4
QA migration dropped `@reexport`s and other foreign names from the namespace.
Those names were never this package's documented public API, so re-exporting them
is not behaviour downstream users were entitled to rely on, and removing them does
not warrant a major bump. Every name the package itself exports is unchanged.

This lowers the version to the next non-breaking release instead.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).