### PR TITLE
Replace the OrdinaryDiffEqDifferentiation cap with a floor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # delete at some point. pinning due to upstream bug in a newer version 3.2.3
+OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # not loaded directly; declared only so [compat] can floor this transitive dep
 
 [weakdeps]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -44,7 +44,7 @@ SciMLTesting = "2.4"
 Symbolics = "6, 7"
 Test = "1"
 julia = "1.10"
-OrdinaryDiffEqDifferentiation = "3.2.0 - 3.2.2" # just to fix a 3.2.3 precompilation bug
+OrdinaryDiffEqDifferentiation = "3.2" # floor only; keeps the lower bound Downgrade CI already exercises
 
 [workspace]
 projects = ["docs"]


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Replaces the `OrdinaryDiffEqDifferentiation` cap with a floor. Supersedes #66.

## Why the cap existed

`ec6cbe0` ("downgraded dependencies whose latest versions are broken", 2026-07-09) added `OrdinaryDiffEqDifferentiation` to `[deps]` purely so `[compat]` could constrain it — nothing in `src/` loads it — and capped it at `3.2.0 - 3.2.2` to dodge a precompilation failure introduced by 3.2.3.

## Why it is no longer needed

3.2.3 shipped an ExplicitImports cleanup (SciML/OrdinaryDiffEq.jl@661f6056) that pruned re-exported names out of `OrdinaryDiffEqDifferentiation`'s namespace — `mul!`, `lmul!`, `axpby!`, `lu`, `fast_scalar_indexing`, `lu_instance`, `constructorof`, `standardtag`, `alg_difftype`, `unwrap_cache`, `_get_fwd_tag`, `TimeGradientWrapper`, `IdentityOperator` and others. `OrdinaryDiffEqRosenbrock` ≤2.3.2 and `OrdinaryDiffEqExtrapolation` were reaching through it for some of those, so *they* failed to precompile, cascading into this package.

That was fixed upstream the same day, at the registry level:

- JuliaRegistries/General#160488 retroactively capped `OrdinaryDiffEqRosenbrock`/`Extrapolation` against `OrdinaryDiffEqDifferentiation` ≥ 3.2.3, so the resolver can no longer construct the broken pair.
- `OrdinaryDiffEqRosenbrock` 2.4.0 (JuliaRegistries/General#160462) lifted its own bound to `OrdinaryDiffEqDifferentiation = "3.2.1 - 3"`.

The bad combination is therefore unreachable, and 3.2.3 itself is a perfectly usable version — the resolver now walks Rosenbrock *forward* to satisfy it. This invariant belongs upstream, where it is actively maintained; restating it here only goes stale.

Note that `OrdinaryDiffEqDifferentiation` 3.4.0's `Expr(:public, ...)` restoration (SciML/OrdinaryDiffEq.jl@abc6fdde) is *not* the fix — `public` declarations affect `names()` and QA only, never precompilation.

## Why a floor rather than deleting the entry

A floor is kept rather than dropping the entry outright because `Downgrade.yml` resolves every `[compat]` entry to its lower bound. The current cap yields a downgrade floor of 3.2.0; a bare `"3"` (or #66's `"3.2.0 - 3.2.2, 3"`, which is the same interval) would drop that to 3.0.0.

`"3.2"` keeps the floor Downgrade CI already exercises, and is the lower bound I actually ran the suite against. I did not lower it to 3.0.0 simply because there is no reason to widen a bound below what is tested — 3.0.0 does resolve and load, but I only smoke-tested it, so I am not proposing it.

For the record, 3.0.0 and 3.2.0 both resolve `OrdinaryDiffEqRosenbrock` to 2.3.0 and both precompile with

```
┌ OrdinaryDiffEqDifferentiation
│  WARNING: could not import SciMLBase.constructorof into OrdinaryDiffEqDifferentiation
└
```

so that warning is *not* a reason to prefer 3.2 over 3 — it is pre-existing at the floor `master` declares today, and this PR neither introduces nor fixes it. It may be worth a separate upstream look.

The alternative worth considering on review is deleting the `[deps]` and `[compat]` entries entirely, letting `OrdinaryDiffEq = "7"` and its transitive compat govern the floor. That removes a phantom direct dependency this package never loads, at the cost of handing the downgrade floor to upstream. I went with the floor because it is the smaller, more conservative change; say the word and I will switch it to a deletion.

## Local verification

Julia 1.11, isolated depot.

At the top of the new range (`OrdinaryDiffEqDifferentiation` v3.5.0, up from the capped v3.2.2):

```
Test Summary:                   | Pass  Total   Time
Sparse Initialization Utilities |   13     13  15.2s
Transforms & Pullback Analytics |   27     27   1.8s
Cost Wrapper Mechanics          |   18     18   2.2s
Public Generic Interfaces       |   13     13   0.8s
Solver Pipelines & Integration  |    8      8  55.4s
Safety Controls & System Guards |    6      6  26.1s
Allocation Checks               |    5      5   2.9s
Explicit Imports Compliance     |    2      2   2.3s
     Testing MinimallyDisruptiveCurves tests passed
```

At the new floor, simulating what Downgrade CI resolves (`OrdinaryDiffEqDifferentiation` pinned to `=3.2.0`, which pulls `OrdinaryDiffEqRosenbrock` back to 2.3.0): the same 92 tests pass.

Also confirmed 3.2.3 — the version the cap was written to exclude — now loads cleanly, resolving `OrdinaryDiffEqRosenbrock` to 2.4.2, and that Aqua's `stale_deps` still passes with the unused direct dep present (it counts transitively-loaded modules as used, so no QA suppression is required).

## Unrelated pre-existing failure noticed

`GROUP=QA` cannot resolve on `master`:

```
ERROR: LoadError: empty intersection between MinimallyDisruptiveCurves@0.4.3 and project compatibility 0.5
```

#72 set `MinimallyDisruptiveCurves = "0.5"` in `test/qa/Project.toml` alongside the 0.5.0 version bump; #73 then walked the package version back to 0.4.3 but only touched the root `Project.toml`, leaving the QA env pinned to a version that no longer exists. QA has been unresolvable since 2026-07-28. Left out of this PR to keep it focused — happy to send the one-line fix separately.
