### PR TITLE
Bump OrdinaryDiffEqDifferentiation lower bound past the broken 3.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # delete at some point. pinning due to upstream bug in a newer version 3.2.3
+OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # not used directly; a direct dep only so the compat bound below can exclude 3.2.3
 
 [weakdeps]
 Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
@@ -46,7 +46,7 @@ SciMLTesting = "2.4"
 Symbolics = "6, 7"
 Test = "1"
 julia = "1.10"
-OrdinaryDiffEqDifferentiation = "3.2.0 - 3.2.2" # just to fix a 3.2.3 precompilation bug
+OrdinaryDiffEqDifferentiation = "3.3" # lower bound skips 3.2.3, which had a precompilation bug
 
 [workspace]
 projects = ["docs"]


### PR DESCRIPTION
Supersedes https://github.com/SciML/MinimallyDisruptiveCurves.jl/pull/78 (and every future CompatHelper PR for this dep).

## The problem

`Project.toml` caps `OrdinaryDiffEqDifferentiation` at `"3.2.0 - 3.2.2"` (added in ec6cbe0) to dodge a precompilation bug in 3.2.3. Because an *upper* cap was used, the entry also excludes 3.3.0 … 3.6.0, so CompatHelper keeps opening PRs to widen it to `"3.2.0 - 3.2.2, 3"` — which lets 3.2.3 straight back in. That will recur on every release.

## The fix

Bump the *lower* bound instead:

```diff
-OrdinaryDiffEqDifferentiation = "3.2.0 - 3.2.2" # just to fix a 3.2.3 precompilation bug
+OrdinaryDiffEqDifferentiation = "3.3" # lower bound skips 3.2.3, which had a precompilation bug
```

`"3.3"` still excludes 3.2.3, admits everything from 3.3.0 through the current 3.6.0, and — because the latest release is now allowed — leaves CompatHelper nothing to open a PR about until 4.0.

This is exactly what upstream did, incidentally: `OrdinaryDiffEqRosenbrock` 2.0.0–2.3.0 carried the same upper-cap hack (`"3 - 3.2.2"`), and from 2.6.3 on it is `"3.3.0 - 3"`.

The `[deps]` comment is updated too: it said "delete at some point", but the entry is what makes the compat bound applicable, so it should stay as long as the exclusion does.

## Why the bound is still needed, rather than relying on OrdinaryDiffEq

The current upstream stack does floor this dep — `OrdinaryDiffEqRosenbrock` >= 2.6.3, `OrdinaryDiffEqBDF` >= 2.4.1 and `OrdinaryDiffEqSDIRK` >= 2.8.2 all require `"3.3.0 - 3"`, and `OrdinaryDiffEqNonlinearSolve` >= 2.6 requires `"3.6.0 - 3"`. So on a newest-versions resolve this bound is redundant.

But it is not redundant under the compat this package *declares*. Every `OrdinaryDiffEq` 7.x release (7.0.0 … 7.2.1) declares only `OrdinaryDiffEqRosenbrock = "2"` and `OrdinaryDiffEqBDF = "2"` — the whole 2.x range — and Rosenbrock 2.4.0–2.6.2 / BDF 2.0.0–2.4.0 all permit 3.2.3. So no bound on `OrdinaryDiffEq` can force the flooring subpackage versions; `OrdinaryDiffEq = "7"` leaves 3.2.3 reachable.

Verified by resolving it directly, with no explicit `OrdinaryDiffEqDifferentiation` bound in play:

```
RESOLVED OrdinaryDiffEq                7.0.0
RESOLVED OrdinaryDiffEqRosenbrock      2.4.0
RESOLVED OrdinaryDiffEqDifferentiation 3.2.3
```

That matters because this repo runs a Downgrade job (`.github/workflows/Downgrade.yml`), which drives deps toward their lower bounds — precisely the resolve that would land on 3.2.3. Hence the explicit direct bound stays.

## Verification (Julia 1.12.4, local)

- Resolves to `OrdinaryDiffEqDifferentiation v3.6.0` and precompiles cleanly.
- `Pkg.test()` passes in full on that resolve — 92 passes, 0 failures:

```
Sparse Initialization Utilities |   13     13  10.6s
Transforms & Pullback Analytics |   27     27   1.8s
Cost Wrapper Mechanics          |   18     18   2.5s
Public Generic Interfaces       |   13     13   0.8s
Solver Pipelines & Integration  |    8      8  32.0s
Safety Controls & System Guards |    6      6  20.3s
Allocation Checks               |    5      5   2.6s
Explicit Imports Compliance     |    2      2  20.5s
     Testing MinimallyDisruptiveCurves tests passed
```

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeSUEdXcEGHSFemNfThw8t
