### PR TITLE
[BLOCKED on OrdinaryDiffEq 7.3.0 registration] Drop the OrdinaryDiffEqDifferentiation phantom dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,6 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # not used directly; a direct dep only so the compat bound below can exclude 3.2.3
 
 [weakdeps]
 Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
@@ -34,7 +33,7 @@ ExplicitImports = "1"
 ForwardDiff = "0.10, 1"
 LinearAlgebra = "1.10"
 Measures = "0.3"
-OrdinaryDiffEq = "7"
+OrdinaryDiffEq = "7.3"
 Plots = "1.40"
 PreallocationTools = "1.2"
 PrecompileTools = "1.0"
@@ -46,7 +45,6 @@ SciMLTesting = "2.4"
 Symbolics = "6, 7"
 Test = "1"
 julia = "1.10"
-OrdinaryDiffEqDifferentiation = "3.3" # lower bound skips 3.2.3, which had a precompilation bug
 
 [workspace]
 projects = ["docs"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # delete at some point. pinning due to upstream bug in a newer version 3.2.3
+OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # not used directly; a direct dep only so the compat bound below can exclude 3.2.3
 
 [weakdeps]
 Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
@@ -46,7 +46,7 @@ SciMLTesting = "2.4"
 Symbolics = "6, 7"
 Test = "1"
 julia = "1.10"
-OrdinaryDiffEqDifferentiation = "3.2.0 - 3.2.2" # just to fix a 3.2.3 precompilation bug
+OrdinaryDiffEqDifferentiation = "3.3" # lower bound skips 3.2.3, which had a precompilation bug
 
 [workspace]
 projects = ["docs"]


### PR DESCRIPTION
> [!WARNING]
> **BLOCKED: do not merge yet.** This requires `OrdinaryDiffEq` 7.3.0, which is merged into master but **not yet registered** in General (registry still tops out at 7.2.1, and no registration PR exists). Until `@JuliaRegistrator register` is run on https://github.com/SciML/OrdinaryDiffEq.jl/commit/d705a2aa0f6867f9cff0a7e5bc1494a02acc7381, `OrdinaryDiffEq = "7.3"` cannot resolve and CI here will fail.

Stacked on https://github.com/SciML/MinimallyDisruptiveCurves.jl/pull/79. That PR's commit is included here because GitHub cannot base a PR on a branch that lives in a fork; once #79 merges into master this diff reduces to the single commit below. Merge #79 first, then this.

## What this does

Removes the `OrdinaryDiffEqDifferentiation` phantom dependency entirely and raises the `OrdinaryDiffEq` floor to `7.3`.

```diff
 [deps]
-OrdinaryDiffEqDifferentiation = "4302a76b-040a-498a-8c04-15b101fed76b" # not used directly; ...

 [compat]
-OrdinaryDiffEq = "7"
+OrdinaryDiffEq = "7.3"
-OrdinaryDiffEqDifferentiation = "3.3" # lower bound skips 3.2.3, ...
```

## Why this is now possible

https://github.com/SciML/OrdinaryDiffEq.jl/pull/4094 raised OrdinaryDiffEq's own floors to `OrdinaryDiffEqRosenbrock = "2.6.3"` and `OrdinaryDiffEqBDF = "2.4.1"`, both of which require `OrdinaryDiffEqDifferentiation = "3.3.0 - 3"`. The broken 3.2.3 is now unreachable through OrdinaryDiffEq alone.

Previously it *was* reachable: OrdinaryDiffEq 7.0.0–7.2.1 declared only `OrdinaryDiffEqRosenbrock = "2"` / `OrdinaryDiffEqBDF = "2"`, and Rosenbrock 2.4.0–2.6.2 / BDF 2.0.0–2.4.0 all permit 3.2.3. That is why #79 needed an explicit bound here, and why the dep could not simply be deleted at the time.

The dep was never referenced anywhere in `src/` — it existed purely as a compat anchor.

## Verification (Julia 1.12.4, local, with OrdinaryDiffEq 7.3.0 `dev`ed from the merged master)

With **no** `OrdinaryDiffEqDifferentiation` bound in this package at all, the floor still holds:

```
RESOLVED OrdinaryDiffEq                  7.3.0
RESOLVED OrdinaryDiffEqRosenbrock        2.6.3
RESOLVED OrdinaryDiffEqBDF               2.4.1
RESOLVED OrdinaryDiffEqDifferentiation   3.6.0
```

3.2.3 is now genuinely unsatisfiable, not merely un-preferred — forcing it fails:

```
Unsatisfiable requirements detected for package OrdinaryDiffEqDifferentiation [4302a76b]:
 ├─possible versions are: 1.0.0 - 3.6.0 or uninstalled
 ├─restricted to versions 3.6.0 - 3 by OrdinaryDiffEqNonlinearSolve [127b3ac7], leaving only versions: 3.6.0
 └─restricted to versions 3.2.3 by an explicit requirement — no versions left
```

`Pkg.test()` passes in full on that resolve — 92 passes, 0 failures:

```
Sparse Initialization Utilities |   13     13  11.1s
Transforms & Pullback Analytics |   27     27   2.0s
Cost Wrapper Mechanics          |   18     18   2.0s
Public Generic Interfaces       |   13     13   0.8s
Solver Pipelines & Integration  |    8      8  32.2s
Safety Controls & System Guards |    6      6  20.2s
Allocation Checks               |    5      5   2.6s
Explicit Imports Compliance     |    2      2  20.3s
     Testing MinimallyDisruptiveCurves tests passed
```

Note this verification used a `dev`ed OrdinaryDiffEq rather than a registered one, since 7.3.0 is not in the registry yet. The resolve CI performs after registration may differ in the exact patch versions selected; the floor guarantee itself comes from OrdinaryDiffEq's declared compat and does not depend on that.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeSUEdXcEGHSFemNfThw8t
