### PR TITLE
Correct version to 0.4.3 (next sequential release)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MinimallyDisruptiveCurves"
 uuid = "c6328df5-4af8-4637-a9e9-78ed74a2ae2b"
-version = "0.4.4"
+version = "0.4.3"
 authors = ["Dhruva Venkita Raman"]
 
 [deps]


### PR DESCRIPTION
Master carried `version = "0.4.4"`, but the General registry latest is `0.4.2`. AutoMerge rejects that under the [sequential version number guideline](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/): from `0.4.2` the legal choices are `1.0.0`, `0.5.0`, `0.4.3`.

This PR sets the version to **0.4.3**.

### Why 0.4.3

The unreleased history is a QA migration that was bumped, downgraded, and bumped again without ever being registered:

| commit | version | change |
|---|---|---|
| `3fb4000` | 0.5.0 | Migrate QA and public API docs to SciMLTesting 2.4 (#72) |
| `b7fb65f` | 0.4.3 | Make the strict-QA release non-breaking (#73) |
| `3987b9f` | 0.4.3 | QA: load the extension triggers so MDCPlotsExt is actually scanned (#77) |
| `f0b5c59` | 0.4.4 | Document developer extension contracts and enforce strict QA (#81) |

The repo already concluded (in #73) that the QA migration is non-breaking, so `0.4.3` is the intended number; `0.4.4` was simply a second bump on top of an unregistered `0.4.3`. All of the above ships as one `0.4.3` release.

### Compat impact

None. No package registered in General depends on MinimallyDisruptiveCurves.

---

Found by a `/sciml-release-sweep` pass over the org. **Please ignore until reviewed by @ChrisRackauckas.**