### PR TITLE
Drop older JuliaSymbolics major versions from compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ SciMLBase = "3.17"
 SciMLPublic = "1"
 SciMLStructures = "1.10"
 SciMLTesting = "2.4"
-Symbolics = "6, 7"
+Symbolics = "7"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop older major versions of JuliaSymbolics packages**. For each maintained dependency, only the current (non-yanked) major remains; an existing lower bound on that major is kept. No code, tests, or package version were changed.

- `Project.toml` [extras] `Symbolics`: `6, 7` → `7` (drop 6; current major is 7)

## Why

JuliaSymbolics is treated as part of the SciML-maintained group for this policy. Supporting multiple majors keeps untested resolver windows. Current majors come from JuliaRegistries/General `Versions.toml`, ignoring `yanked = true` releases.

## Verification

Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
